### PR TITLE
SEO Boost to the spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Members of the Working Group are engaged in contributing to specs that embody a method for secure, private and authenticated message-based communication, where trust is rooted in DIDs and used over a wide variety of transports.
 
+For the current DIDComm spec, see [here](https://identity.foundation/didcomm-messaging/spec/).
+
 ## General Information
 
 - [Website page](https://identity.foundation/working-groups/did-comm.html)


### PR DESCRIPTION
depending on search terms, looking for didcomm often gets you to the WG github instead of the spec github. Group might also want to link to the spec from the wg repo's "About" section link?